### PR TITLE
Escape search results text

### DIFF
--- a/docs/search.js
+++ b/docs/search.js
@@ -1,10 +1,11 @@
 async function load(u){const r=await fetch(u);const t=await r.text();return t.split("\n").filter(Boolean).map(JSON.parse)}
 function hit(r,q){q=q.toLowerCase();return r.text.toLowerCase().includes(q)}
+const esc=s=>s.replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
 (async()=>{
   const data=await load("../index.jsonl");
   const q=document.getElementById("q"),res=document.getElementById("res");
   function render(list){
-    res.innerHTML=list.slice(0,200).map(r=>`<div><a href="${r.url}" target="_blank">${r.file}</a> — p.${r.page}<br>${r.text}</div><hr>`).join("")
+    res.innerHTML=list.slice(0,200).map(r=>`<div><a href="${r.url}" target="_blank">${r.file}</a> — p.${r.page}<br>${esc(r.text)}</div><hr>`).join("")
   }
   q.addEventListener("input",()=>{const v=q.value.trim(); if(!v){res.innerHTML=""; return} render(data.filter(r=>hit(r,v)));});
 })();

--- a/scripts/test_escape.js
+++ b/scripts/test_escape.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+
+const esc = s => s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+
+assert.strictEqual(esc('<script>'), '&lt;script&gt;');
+
+console.log('escape ok');


### PR DESCRIPTION
## Summary
- escape special HTML characters before rendering search results
- add a Node test verifying `<script>` strings are escaped

## Testing
- `node scripts/test_escape.js`


------
https://chatgpt.com/codex/tasks/task_e_68b423a7d28c832c951b8fc1df287b1d