### PR TITLE
fix: validate OCR tools before processing PDFs

### DIFF
--- a/make_pdfs_searchable.sh
+++ b/make_pdfs_searchable.sh
@@ -3,12 +3,19 @@ set -euo pipefail
 shopt -s nullglob
 # ต้องติดตั้ง ocrmypdf ไว้แล้ว
 
+if ! ocrmypdf --version >/dev/null 2>&1; then
+  echo "Install ocrmypdf first (brew install ocrmypdf)"
+  exit 1
+fi
+
+if ! command -v pdffonts >/dev/null 2>&1; then
+  echo "Install pdffonts first (e.g., from poppler-utils)"
+  exit 1
+fi
+
 for f in *.pdf; do
-  if ! ocrmypdf --version >/dev/null 2>&1; then
-    echo "Install ocrmypdf first (brew install ocrmypdf)"; exit 1
-  fi
-  # ตรวจว่ามี text layer ไหม: ถ้าไม่มีจะมีคำว่า "no text"
-  if pdffonts "$f" 2>/dev/null | grep -qi "no fonts\|no text"; then
+  # ตรวจว่ามี text layer ไหม: ถ้าไม่มีจะมีคำว่า \"no text\"
+  if pdffonts "$f" 2>/dev/null | grep -qi "no fonts\\|no text"; then
     tmp="ocr_$f"
     ocrmypdf --skip-text "$f" "$tmp"
     mv "$tmp" "$f"


### PR DESCRIPTION
## Summary
- check `ocrmypdf` and `pdffonts` once before processing
- fail fast with a single install prompt

## Testing
- `bash -n make_pdfs_searchable.sh`
- `shellcheck make_pdfs_searchable.sh`
- `bash make_pdfs_searchable.sh` *(fails: Install ocrmypdf first (brew install ocrmypdf))*

------
https://chatgpt.com/codex/tasks/task_e_68b423a88e00832ca15bf2e17b3f7243