### PR TITLE
fix: correct PDF links

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,733 +14,733 @@ tr>:nth-child(6) { text-align: right; }
 </head>
 <body>
 <h2>All_Case_Parties (8/30/2025)</h2><table width="99%" border="1" ><tr><th><b>Subject</b></th><th><b>From</b></th><th><b>To</b></th><th><b>Date</b></th><th><b><img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAsTAAALEwEAmpwYAAADFUlEQVR4nO2aTagOURjHH+KGuMXCZ0m3aycLKcqGEsICG2VhYXG7xYIsRSzIRjZ0EYnkY+EjG4qV8rWyQG5ZKPmIheQj3x/Pv5k3c+d9zpw5M2dm3nM9v/p33/vOOU/Pf94z55x5ZogURVEURVEURVEUpZPoYi1irWf1sdax5rNGNplUHcxlnWd9YP0R9JY1wJrZVIJVMYZ1jPWLZONpfWXtZI1oIlnfTGHdo3zG07pM0ckLlsmsh1TMfEuna8/aE/jlH1O2uR+sd6zflnabas69NDbz91krKFoNwHjWBtZTQ/sXrLH1pV8Om/mTrNGGvt2sW4Z+QYwCm/njZF/rMW+8F/peqiZlf/gw3+Kg0P+N53y94tM8WCvEwB7CdOk0im/zYJkhVreflP3hYh67ukOs5TnibhFiffaZuA9czQ/E3z8j+1C+K8R74Df9criaP5I6viQjdp8h5l7fJoqCZaqMeajfEBuT33ehPSbAOf6tuIOd220qZx7aKMQ2mYfOVOKmANLk5Goe+/6eVNws869Y06sy5MojkpM8QfnMQxdSMbPMf2EtrMyNIxNJTvIs5Tf/hDUpEdNmPs+SWSmY7WfEn3tJTnRBfNxmfpA1LRE7CPMY8kvj/00j4CJFw/SU4XiQ5jFMW9f7tsT3pjkgSxj2SfNrqMPNj2LdoH9JXU8cy1oFhoV5sIOGJoZNSG98DPuAOzSMzWPoS8WIq4k22AlmbYYgnKSpiT5BmAdbSU7yHA2t0eNmZjO1V3wxR+Ay6Uq0DcY8uEntSaIgOS6jD1aHnvhvmqDMA2n47y4YKzjzKDtLya4qECs482ACyQm7Jtvxm5wsPlF70tsd+gdtHkgPMTHT5ylqBm8e7CLZwB5LP7zgELx5MIv1jWQjh6l9qcPEiZP209AnKPMtULo27fAwR1xjHWVdoejJrqltkOYBVoMid31J4Q2P1XUn7pPZrNdUzPxHCvSXT4NCJJ7ju5h/zprXRLJVgZsePKh4SfZffT914LM7X6BIspi1j6IaPQomqO4eYK2kgN7eUBRFURRF+S/4CwPqfEibwrHFAAAAAElFTkSuQmCC' height='20px' width='20px'></b></th><th><b>Size</b></th></tr>
-<tr><td><a href="messages/20250828-Re_1803_243%20Franklin%20Street%2C%20Melbourne%20VIC%203000%20-%20-162.pdf">Re: 1803/243 Franklin Street, Melbourne VIC 3000 - Not</a></td>
+<tr><td><a href="20250828-Re_1803_243%20Franklin%20Street%2C%20Melbourne%20VIC%203000%20-%20-162.pdf">Re: 1803/243 Franklin Street, Melbourne VIC 3000 - Not</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Shaun Young &lt;shaun.young@areal.com.au&gt;</td>
 <td nowrap>8/28/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">292.75 KB</td></tr>
-<tr><td><a href="messages/20250827-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-161.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
+<tr><td><a href="20250827-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-161.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>8/27/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">127.47 KB</td></tr>
-<tr><td><a href="messages/20250822-1803_243%20Franklin%20Street%2C%20Melbourne%20VIC%203000%20-%20Not-160.pdf">1803/243 Franklin Street, Melbourne VIC 3000 - Not</a></td>
+<tr><td><a href="20250822-1803_243%20Franklin%20Street%2C%20Melbourne%20VIC%203000%20-%20Not-160.pdf">1803/243 Franklin Street, Melbourne VIC 3000 - Not</a></td>
 <td>Shaun Young &lt;shaun.young@areal.com.au&gt;</td>
 <td>ck.chawakorn@gmail.com" &lt;ck.chawakorn@gmail.com&gt;,</td>
 <td nowrap>8/22/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">2.49 MB</td></tr>
-<tr><td><a href="messages/20250819-Re_Without%20Prejudice%20%E2%80%94%20Franklin%201803_%20Settlement%20T-148.pdf">Re: Without Prejudice — Franklin 1803: Settlement Term</a></td>
+<tr><td><a href="20250819-Re_Without%20Prejudice%20%E2%80%94%20Franklin%201803_%20Settlement%20T-148.pdf">Re: Without Prejudice — Franklin 1803: Settlement Term</a></td>
 <td>Jamie Ong &lt;jamie.ong@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>8/19/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">301.54 KB</td></tr>
-<tr><td><a href="messages/20250817-%20Without%20Prejudice%20%E2%80%94%20Franklin%201803_%20Settlement%20Ter-147.pdf"> Without Prejudice — Franklin 1803: Settlement Ter</a></td>
+<tr><td><a href="20250817-%20Without%20Prejudice%20%E2%80%94%20Franklin%201803_%20Settlement%20Ter-147.pdf"> Without Prejudice — Franklin 1803: Settlement Ter</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>jamie.ong@areal.com.au</td>
 <td nowrap>8/17/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">991.79 KB</td></tr>
-<tr><td><a href="messages/20250815-VCAT%20order%20made%20about%20R202518589_00%201803_243%20Frank-146.pdf">VCAT order made about R202518589/00 1803/243 Frank</a></td>
+<tr><td><a href="20250815-VCAT%20order%20made%20about%20R202518589_00%201803_243%20Frank-146.pdf">VCAT order made about R202518589/00 1803/243 Frank</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>8/15/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">39.59 KB</td></tr>
-<tr><td><a href="messages/20250812-Re_R202518589_00%20-%20Summary%20of%20Proof-145.pdf">Re: R202518589/00 - Summary of Proof</a></td>
+<tr><td><a href="20250812-Re_R202518589_00%20-%20Summary%20of%20Proof-145.pdf">Re: R202518589/00 - Summary of Proof</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Shaun Young &lt;shaun.young@areal.com.au&gt;</td>
 <td nowrap>8/12/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">307.7 KB</td></tr>
-<tr><td><a href="messages/20250812-R202518589_00%20-%20Summary%20of%20Proof-144.pdf">R202518589/00 - Summary of Proof</a></td>
+<tr><td><a href="20250812-R202518589_00%20-%20Summary%20of%20Proof-144.pdf">R202518589/00 - Summary of Proof</a></td>
 <td>Shaun Young &lt;shaun.young@areal.com.au&gt;</td>
 <td>renting@vcat.vic.gov.au" &lt;renting@vcat.vic.gov.au</td>
 <td nowrap>8/12/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">2.66 MB</td></tr>
-<tr><td><a href="messages/20250808-Hearing%20reminder%20for%201803_243%20Franklin%20Street%2C%20MEL-141.pdf">Hearing reminder for 1803/243 Franklin Street, MEL</a></td>
+<tr><td><a href="20250808-Hearing%20reminder%20for%201803_243%20Franklin%20Street%2C%20MEL-141.pdf">Hearing reminder for 1803/243 Franklin Street, MEL</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>8/08/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">50.07 KB</td></tr>
-<tr><td><a href="messages/20250801-Areal%20monthly%20after-hours%20trades%20list%20update-114.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250801-Areal%20monthly%20after-hours%20trades%20list%20update-114.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>8/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.43 KB</td></tr>
-<tr><td><a href="messages/20250725-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-113.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
+<tr><td><a href="20250725-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-113.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/25/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">127.64 KB</td></tr>
-<tr><td><a href="messages/20250724-VCAT%20evidence%20link%20R202518589%20about%201803_243%20Frank-112.pdf">VCAT evidence link R202518589 about 1803/243 Frank</a></td>
+<tr><td><a href="20250724-VCAT%20evidence%20link%20R202518589%20about%201803_243%20Frank-112.pdf">VCAT evidence link R202518589 about 1803/243 Frank</a></td>
 <td>CSV-VCAT-No reply Renting Upload (CSV)" &lt;Noreply_</td>
 <td>ck.chawakorn@gmail.com" &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">102.46 KB</td></tr>
-<tr><td><a href="messages/20250723-VCAT%20RDRV%20account%20email%20verification%20code-3.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250723-VCAT%20RDRV%20account%20email%20verification%20code-3.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.31 KB</td></tr>
-<tr><td><a href="messages/20250723-VCAT%20RDRV%20account%20email%20verification%20code-2.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250723-VCAT%20RDRV%20account%20email%20verification%20code-2.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.28 KB</td></tr>
-<tr><td><a href="messages/20250723-VCAT%20RDRV%20account%20email%20verification%20code-1.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250723-VCAT%20RDRV%20account%20email%20verification%20code-1.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.29 KB</td></tr>
-<tr><td><a href="messages/20250723-VCAT%20order%20made%20about%20R202518589_00%201803_243%20Frank-4.pdf">VCAT order made about R202518589/00 1803/243 Frank</a></td>
+<tr><td><a href="20250723-VCAT%20order%20made%20about%20R202518589_00%201803_243%20Frank-4.pdf">VCAT order made about R202518589/00 1803/243 Frank</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">39.58 KB</td></tr>
-<tr><td><a href="messages/20250722-Re_VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to%20N-8.pdf">Re: VCAT Application R202518214/00 – Challenge to Noti</a></td>
+<tr><td><a href="20250722-Re_VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to%20N-8.pdf">Re: VCAT Application R202518214/00 – Challenge to Noti</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, bew</td>
 <td nowrap>7/22/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">80.07 KB</td></tr>
-<tr><td><a href="messages/20250722-Hearing%20scheduled%20for%20R202518589_00%201803_243%20Frank-9.pdf">Hearing scheduled for R202518589/00 1803/243 Frank</a></td>
+<tr><td><a href="20250722-Hearing%20scheduled%20for%20R202518589_00%201803_243%20Frank-9.pdf">Hearing scheduled for R202518589/00 1803/243 Frank</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/22/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">70.27 KB</td></tr>
-<tr><td><a href="messages/20250722-VCAT%20order%20made%20about%20R202518214_00%20243%20Franklin%20S-10.pdf">VCAT order made about R202518214/00 243 Franklin S</a></td>
+<tr><td><a href="20250722-VCAT%20order%20made%20about%20R202518214_00%20243%20Franklin%20S-10.pdf">VCAT order made about R202518214/00 243 Franklin S</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/22/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">39.58 KB</td></tr>
-<tr><td><a href="messages/20250721-VCAT%20has%20opened%20a%20case%20R202518589_00%20about%20%201803_2-11.pdf">VCAT has opened a case R202518589/00 about  1803/2</a></td>
+<tr><td><a href="20250721-VCAT%20has%20opened%20a%20case%20R202518589_00%20about%20%201803_2-11.pdf">VCAT has opened a case R202518589/00 about  1803/2</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/21/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">49.36 KB</td></tr>
-<tr><td><a href="messages/20250721-VCAT%20Application%20%E2%80%93%20Possession%20of%20Property%20(Ref_%20R2-12.pdf">VCAT Application – Possession of Property (Ref: R2</a></td>
+<tr><td><a href="20250721-VCAT%20Application%20%E2%80%93%20Possession%20of%20Property%20(Ref_%20R2-12.pdf">VCAT Application – Possession of Property (Ref: R2</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, bew</td>
 <td nowrap>7/21/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">92.2 KB</td></tr>
-<tr><td><a href="messages/20250717-VCAT%20RDRV%20account%20email%20verification%20code-13.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250717-VCAT%20RDRV%20account%20email%20verification%20code-13.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/17/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.31 KB</td></tr>
-<tr><td><a href="messages/20250715-Automated%20response%20-%20VCAT%20Residential%20Tenancies-15.pdf">Automated response - VCAT Residential Tenancies</a></td>
+<tr><td><a href="20250715-Automated%20response%20-%20VCAT%20Residential%20Tenancies-15.pdf">Automated response - VCAT Residential Tenancies</a></td>
 <td>CSV-VCAT-RT Inbox (CSV)" &lt;renting@courts.vic.gov.</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/15/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">30.29 KB</td></tr>
-<tr><td><a href="messages/20250715-Re_Your%20VCAT%20application_%20more%20information%20needed--17.pdf">Re: Your VCAT application: more information needed- VC</a></td>
+<tr><td><a href="20250715-Re_Your%20VCAT%20application_%20more%20information%20needed--17.pdf">Re: Your VCAT application: more information needed- VC</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>CSV-VCAT-RT Inbox (CSV)" &lt;renting@courts.vic.gov.</td>
 <td nowrap>7/15/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">162.63 KB</td></tr>
-<tr><td><a href="messages/20250715-Automated%20response%20-%20VCAT%20Residential%20Tenancies-14.pdf">Automated response - VCAT Residential Tenancies</a></td>
+<tr><td><a href="20250715-Automated%20response%20-%20VCAT%20Residential%20Tenancies-14.pdf">Automated response - VCAT Residential Tenancies</a></td>
 <td>CSV-VCAT-RT Inbox (CSV)" &lt;renting@courts.vic.gov.</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/15/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">30.3 KB</td></tr>
-<tr><td><a href="messages/20250715-Fwd_%20VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to-7.pdf">Fwd: VCAT Application R202518214/00 – Challenge to</a></td>
+<tr><td><a href="20250715-Fwd_%20VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to-7.pdf">Fwd: VCAT Application R202518214/00 – Challenge to</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>renting@courts.vic.gov.au</td>
 <td nowrap>7/15/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">119.48 KB</td></tr>
-<tr><td><a href="messages/20250715-Your%20VCAT%20application_%20more%20information%20needed-%20VC-16.pdf">Your VCAT application: more information needed- VC</a></td>
+<tr><td><a href="20250715-Your%20VCAT%20application_%20more%20information%20needed-%20VC-16.pdf">Your VCAT application: more information needed- VC</a></td>
 <td>CSV-VCAT-RT Inbox (CSV)" &lt;renting@courts.vic.gov.</td>
 <td>ck.chawakorn@gmail.com" &lt;ck.chawakorn@gmail.com&gt;,</td>
 <td nowrap>7/15/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">74.31 KB</td></tr>
-<tr><td><a href="messages/20250715-VCAT%20RDRV%20account%20email%20verification%20code-18.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250715-VCAT%20RDRV%20account%20email%20verification%20code-18.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/15/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.29 KB</td></tr>
-<tr><td><a href="messages/20250714-You%20have%20reached%20us%20outside%20of%20business%20hours-19.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250714-You%20have%20reached%20us%20outside%20of%20business%20hours-19.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/14/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.34 KB</td></tr>
-<tr><td><a href="messages/20250714-VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to%20Noti-5.pdf">VCAT Application R202518214/00 – Challenge to Noti</a></td>
+<tr><td><a href="20250714-VCAT%20Application%20R202518214_00%20%E2%80%93%20Challenge%20to%20Noti-5.pdf">VCAT Application R202518214/00 – Challenge to Noti</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;mpm@</td>
 <td nowrap>7/14/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">118.33 KB</td></tr>
-<tr><td><a href="messages/20250714-VCAT%20has%20opened%20a%20case%20R202518214_00%20about%20%20243%20Fr-20.pdf">VCAT has opened a case R202518214/00 about  243 Fr</a></td>
+<tr><td><a href="20250714-VCAT%20has%20opened%20a%20case%20R202518214_00%20about%20%20243%20Fr-20.pdf">VCAT has opened a case R202518214/00 about  243 Fr</a></td>
 <td>Residential Tenancies &lt;renting@vcat.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/14/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">49.38 KB</td></tr>
-<tr><td><a href="messages/20250714-VCAT%20Residential%20Tenancies%20Hub%20-%20Please%20confirm%20yo-21.pdf">VCAT Residential Tenancies Hub - Please confirm yo</a></td>
+<tr><td><a href="20250714-VCAT%20Residential%20Tenancies%20Hub%20-%20Please%20confirm%20yo-21.pdf">VCAT Residential Tenancies Hub - Please confirm yo</a></td>
 <td>VCAT Residential Tenancies Hub: New Registration"</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/14/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">8.92 KB</td></tr>
-<tr><td><a href="messages/20250714-VCAT%20RDRV%20account%20email%20verification%20code-22.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250714-VCAT%20RDRV%20account%20email%20verification%20code-22.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>7/14/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.21 KB</td></tr>
-<tr><td><a href="messages/20250711-Vacating%20instructions%20-%201803_243%20Franklin%20Street%2C%20-23.pdf">Vacating instructions - 1803/243 Franklin Street, </a></td>
+<tr><td><a href="20250711-Vacating%20instructions%20-%201803_243%20Franklin%20Street%2C%20-23.pdf">Vacating instructions - 1803/243 Franklin Street, </a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/11/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">111.33 KB</td></tr>
-<tr><td><a href="messages/20250711-Notice%20to%20vacate%20-%201803_243%20Franklin%20Street%2C%20Melbo-24.pdf">Notice to vacate - 1803/243 Franklin Street, Melbo</a></td>
+<tr><td><a href="20250711-Notice%20to%20vacate%20-%201803_243%20Franklin%20Street%2C%20Melbo-24.pdf">Notice to vacate - 1803/243 Franklin Street, Melbo</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/11/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">187.87 KB</td></tr>
-<tr><td><a href="messages/20250711-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-42.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250711-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-42.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td nowrap>7/11/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">894.44 KB</td></tr>
-<tr><td><a href="messages/20250709-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-41.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250709-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-41.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, Are</td>
 <td nowrap>7/09/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">410.61 KB</td></tr>
-<tr><td><a href="messages/20250707-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-40.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250707-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-40.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, Are</td>
 <td nowrap>7/07/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">396.24 KB</td></tr>
-<tr><td><a href="messages/20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-39.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-39.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td nowrap>7/04/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">81.22 KB</td></tr>
-<tr><td><a href="messages/20250704-You%20have%20reached%20us%20outside%20of%20business%20hours-43.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250704-You%20have%20reached%20us%20outside%20of%20business%20hours-43.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/04/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.23 KB</td></tr>
-<tr><td><a href="messages/20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-38.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-38.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td nowrap>7/04/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">79.56 KB</td></tr>
-<tr><td><a href="messages/20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-37.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250704-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-37.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/04/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">187.78 KB</td></tr>
-<tr><td><a href="messages/20250703-You%20have%20reached%20us%20outside%20of%20business%20hours-44.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250703-You%20have%20reached%20us%20outside%20of%20business%20hours-44.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/03/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.24 KB</td></tr>
-<tr><td><a href="messages/20250703-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-36.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250703-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-36.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td nowrap>7/03/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">19.49 KB</td></tr>
-<tr><td><a href="messages/20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-35.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-35.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/01/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">1.2 MB</td></tr>
-<tr><td><a href="messages/20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-34.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-34.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">765.15 KB</td></tr>
-<tr><td><a href="messages/20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-33.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250701-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-33.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td nowrap>7/01/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">1.64 MB</td></tr>
-<tr><td><a href="messages/20250701-Areal%20monthly%20after-hours%20trades%20list%20update-46.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250701-Areal%20monthly%20after-hours%20trades%20list%20update-46.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.16 KB</td></tr>
-<tr><td><a href="messages/20250701-Areal%20monthly%20after-hours%20trades%20list%20update-45.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250701-Areal%20monthly%20after-hours%20trades%20list%20update-45.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>7/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.15 KB</td></tr>
-<tr><td><a href="messages/20250627-VCAT%20RDRV%20account%20email%20verification%20code-47.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250627-VCAT%20RDRV%20account%20email%20verification%20code-47.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/27/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.3 KB</td></tr>
-<tr><td><a href="messages/20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-32.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-32.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, CS</td>
 <td nowrap>6/27/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">1.07 MB</td></tr>
-<tr><td><a href="messages/20250627-RDRV%20Order%20-%20RT252398%20CMS_0014256123-48.pdf">RDRV Order - RT252398 CMS:0014256123</a></td>
+<tr><td><a href="20250627-RDRV%20Order%20-%20RT252398%20CMS_0014256123-48.pdf">RDRV Order - RT252398 CMS:0014256123</a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;cases@courts.vic.gov.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/27/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">216.63 KB</td></tr>
-<tr><td><a href="messages/20250627-Update%20to%20RT252398%20CMS_0014256122-49.pdf">Update to RT252398 CMS:0014256122</a></td>
+<tr><td><a href="20250627-Update%20to%20RT252398%20CMS_0014256122-49.pdf">Update to RT252398 CMS:0014256122</a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;cases@courts.vic.gov.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/27/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">37.66 KB</td></tr>
-<tr><td><a href="messages/20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-50.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-50.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;cases@courts.vic.gov.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/27/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">461.58 KB</td></tr>
-<tr><td><a href="messages/20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-31.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250627-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-31.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, CS</td>
 <td nowrap>6/27/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">789.18 KB</td></tr>
-<tr><td><a href="messages/20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-30.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-30.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, CS</td>
 <td nowrap>6/26/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">713.69 KB</td></tr>
-<tr><td><a href="messages/20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-29.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-29.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td nowrap>6/26/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">366.81 KB</td></tr>
-<tr><td><a href="messages/20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-28.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250626-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-28.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td nowrap>6/26/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">378.95 KB</td></tr>
-<tr><td><a href="messages/20250625-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-27.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250625-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-27.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td nowrap>6/25/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">401.92 KB</td></tr>
-<tr><td><a href="messages/20250625-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-26.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250625-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-26.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td nowrap>6/25/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">363.92 KB</td></tr>
-<tr><td><a href="messages/20250625-RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawthorn%20-25.pdf">RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250625-RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawthorn%20-25.pdf">RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td>Johnson Tan &lt;johnson.tan@areal.com.au&gt;</td>
 <td nowrap>6/25/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">59.41 KB</td></tr>
-<tr><td><a href="messages/20250624-You%20have%20reached%20us%20outside%20of%20business%20hours-51.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250624-You%20have%20reached%20us%20outside%20of%20business%20hours-51.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.23 KB</td></tr>
-<tr><td><a href="messages/20250624-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-56.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250624-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-56.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">235.98 KB</td></tr>
-<tr><td><a href="messages/20250624-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-58.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250624-Re_RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawtho-58.pdf">Re: RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.78 KB</td></tr>
-<tr><td><a href="messages/20250624-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-59.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
+<tr><td><a href="20250624-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-59.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/24/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">127.31 KB</td></tr>
-<tr><td><a href="messages/20250624-RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawthorn%20-57.pdf">RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
+<tr><td><a href="20250624-RDRV%20-%20Case%20RT252398%20-%2033%20Camberwell%20Rd%2C%20Hawthorn%20-57.pdf">RDRV - Case RT252398 - 33 Camberwell Rd, Hawthorn </a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;Cases@courts.vic.gov.au&gt;</td>
 <td>ck.chawakorn@gmail.com" &lt;ck.chawakorn@gmail.com&gt;,</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">54.93 KB</td></tr>
-<tr><td><a href="messages/20250624-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-55.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250624-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-55.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">189.75 KB</td></tr>
-<tr><td><a href="messages/20250624-Residential%20Tenancies%20Dispute%20Submission%20for%20RT252-60.pdf">Residential Tenancies Dispute Submission for RT252</a></td>
+<tr><td><a href="20250624-Residential%20Tenancies%20Dispute%20Submission%20for%20RT252-60.pdf">Residential Tenancies Dispute Submission for RT252</a></td>
 <td>CSV-VCAT-Cases (CSV)" &lt;cases@courts.vic.gov.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/24/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">192.35 KB</td></tr>
-<tr><td><a href="messages/20250624-VCAT%20RDRV%20account%20email%20verification%20code-61.pdf">VCAT RDRV account email verification code</a></td>
+<tr><td><a href="20250624-VCAT%20RDRV%20account%20email%20verification%20code-61.pdf">VCAT RDRV account email verification code</a></td>
 <td>Microsoft on behalf of VCAT RDRV &lt;msonlineservices</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">16.4 KB</td></tr>
-<tr><td><a href="messages/20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-54.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-54.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/23/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">232.08 KB</td></tr>
-<tr><td><a href="messages/20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-53.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-53.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td nowrap>6/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">127.21 KB</td></tr>
-<tr><td><a href="messages/20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-52.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250623-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-52.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Johnson Tan - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/23/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">198.89 KB</td></tr>
-<tr><td><a href="messages/20250618-Remediation%20Works%20%E2%80%93%20Start%20Date%20Confirmed-62.pdf">Remediation Works – Start Date Confirmed</a></td>
+<tr><td><a href="20250618-Remediation%20Works%20%E2%80%93%20Start%20Date%20Confirmed-62.pdf">Remediation Works – Start Date Confirmed</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, bew</td>
 <td nowrap>6/18/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">50.28 KB</td></tr>
-<tr><td><a href="messages/20250616-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-72.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250616-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-72.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/16/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">176.81 KB</td></tr>
-<tr><td><a href="messages/20250616-You%20have%20reached%20us%20outside%20of%20business%20hours-73.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250616-You%20have%20reached%20us%20outside%20of%20business%20hours-73.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/16/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.34 KB</td></tr>
-<tr><td><a href="messages/20250616-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-71.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250616-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-71.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td nowrap>6/16/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">133.3 KB</td></tr>
-<tr><td><a href="messages/20250613-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-70.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250613-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-70.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/13/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">261.49 KB</td></tr>
-<tr><td><a href="messages/20250613-You%20have%20reached%20us%20outside%20of%20business%20hours-74.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250613-You%20have%20reached%20us%20outside%20of%20business%20hours-74.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/13/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.24 KB</td></tr>
-<tr><td><a href="messages/20250613-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-69.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250613-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-69.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td nowrap>6/13/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">242.07 KB</td></tr>
-<tr><td><a href="messages/20250612-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-68.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250612-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-68.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/12/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">180.67 KB</td></tr>
-<tr><td><a href="messages/20250611-You%20have%20reached%20us%20outside%20of%20business%20hours-75.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250611-You%20have%20reached%20us%20outside%20of%20business%20hours-75.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/11/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.24 KB</td></tr>
-<tr><td><a href="messages/20250611-Re_Rent%20Adjustment%20%E2%80%93%20Request%20for%20Clarification%20and-76.pdf">Re: Rent Adjustment – Request for Clarification and Me</a></td>
+<tr><td><a href="20250611-Re_Rent%20Adjustment%20%E2%80%93%20Request%20for%20Clarification%20and-76.pdf">Re: Rent Adjustment – Request for Clarification and Me</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td nowrap>6/11/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">135.58 KB</td></tr>
-<tr><td><a href="messages/20250610-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-67.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250610-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-67.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, bew</td>
 <td nowrap>6/10/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">156.5 KB</td></tr>
-<tr><td><a href="messages/20250610-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-66.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250610-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-66.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;, bew</td>
 <td nowrap>6/10/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">101.6 KB</td></tr>
-<tr><td><a href="messages/20250606-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-65.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250606-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-65.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td nowrap>6/06/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">54.1 KB</td></tr>
-<tr><td><a href="messages/20250606-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-64.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250606-Re_Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding-64.pdf">Re: Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/06/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">57.76 KB</td></tr>
-<tr><td><a href="messages/20250606-You%20have%20reached%20us%20outside%20of%20business%20hours-77.pdf">You have reached us outside of business hours</a></td>
+<tr><td><a href="20250606-You%20have%20reached%20us%20outside%20of%20business%20hours-77.pdf">You have reached us outside of business hours</a></td>
 <td>Areal Property Hawthorn (MPM)" &lt;MPM@email.propert</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/06/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">32.24 KB</td></tr>
-<tr><td><a href="messages/20250606-Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding%20Un-63.pdf">Follow-up – Formal Demand & Statement Regarding Un</a></td>
+<tr><td><a href="20250606-Follow-up%20%E2%80%93%20Formal%20Demand%20%26%20Statement%20Regarding%20Un-63.pdf">Follow-up – Formal Demand & Statement Regarding Un</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;mpm@</td>
 <td nowrap>6/06/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">12.35 KB</td></tr>
-<tr><td><a href="messages/20250605-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-82.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
+<tr><td><a href="20250605-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-82.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/05/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">194.03 KB</td></tr>
-<tr><td><a href="messages/20250603-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-81.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
+<tr><td><a href="20250603-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-81.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td nowrap>6/03/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">150.26 KB</td></tr>
-<tr><td><a href="messages/20250603-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-80.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
+<tr><td><a href="20250603-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-80.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com, bewty980219@gmail.com</td>
 <td nowrap>6/03/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">194.7 KB</td></tr>
-<tr><td><a href="messages/20250602-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-79.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
+<tr><td><a href="20250602-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-79.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>6/02/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">134.06 KB</td></tr>
-<tr><td><a href="messages/20250602-Areal%20monthly%20after-hours%20trades%20list%20update-83.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250602-Areal%20monthly%20after-hours%20trades%20list%20update-83.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>6/02/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.12 KB</td></tr>
-<tr><td><a href="messages/20250529-Leak%20Rectification%20Works%20%E2%80%93%20Access%20Required-84.pdf">Leak Rectification Works – Access Required</a></td>
+<tr><td><a href="20250529-Leak%20Rectification%20Works%20%E2%80%93%20Access%20Required-84.pdf">Leak Rectification Works – Access Required</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>5/29/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">50.27 KB</td></tr>
-<tr><td><a href="messages/20250526-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-85.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
+<tr><td><a href="20250526-Receipt%20of%20payment%20for%201803_243%20Franklin%20Street%2C%20M-85.pdf">Receipt of payment for 1803/243 Franklin Street, M</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>5/26/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">127.13 KB</td></tr>
-<tr><td><a href="messages/20250513-Re_PS628109B%20-%20R%26M%20-%20Water%20Leak%20Lot%201803A%20-%20243%2C%202-86.pdf">Re: PS628109B - R&M - Water Leak Lot 1803A - 243, 253 </a></td>
+<tr><td><a href="20250513-Re_PS628109B%20-%20R%26M%20-%20Water%20Leak%20Lot%201803A%20-%20243%2C%202-86.pdf">Re: PS628109B - R&M - Water Leak Lot 1803A - 243, 253 </a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Sophia Giuliano &lt;sophiag@highrisestrata.com.au&gt;</td>
 <td nowrap>5/13/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">191.81 KB</td></tr>
-<tr><td><a href="messages/20250512-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-78.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
+<tr><td><a href="20250512-Re_FW_%20Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_-78.pdf">Re: FW: Follow-up on Wall and Carpet Damage – 1803/243</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>5/12/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">81.6 KB</td></tr>
-<tr><td><a href="messages/20250510-Re_Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20-89.pdf">Re: Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
+<tr><td><a href="20250510-Re_Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20-89.pdf">Re: Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Sylvia Hao &lt;sylvia.hao@areal.com.au&gt;</td>
 <td nowrap>5/10/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">2.93 MB</td></tr>
-<tr><td><a href="messages/20250509-Re_Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20-88.pdf">Re: Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
+<tr><td><a href="20250509-Re_Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20-88.pdf">Re: Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
 <td>Sylvia Hao &lt;sylvia.hao@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>5/09/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">319.51 KB</td></tr>
-<tr><td><a href="messages/20250509-Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20Fra-87.pdf">Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
+<tr><td><a href="20250509-Follow-up%20on%20Wall%20and%20Carpet%20Damage%20%E2%80%93%201803_243%20Fra-87.pdf">Follow-up on Wall and Carpet Damage – 1803/243 Fra</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>sylvia.hao@areal.com.au</td>
 <td nowrap>5/09/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">2.78 KB</td></tr>
-<tr><td><a href="messages/20250502-Leaking%20Repaired%20Confirmation%20%20-%201803_243%20Franklin-90.pdf">Leaking Repaired Confirmation  - 1803/243 Franklin</a></td>
+<tr><td><a href="20250502-Leaking%20Repaired%20Confirmation%20%20-%201803_243%20Franklin-90.pdf">Leaking Repaired Confirmation  - 1803/243 Franklin</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>5/02/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">50.1 KB</td></tr>
-<tr><td><a href="messages/20250501-Areal%20monthly%20after-hours%20trades%20list%20update-91.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250501-Areal%20monthly%20after-hours%20trades%20list%20update-91.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>5/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.46 KB</td></tr>
-<tr><td><a href="messages/20250430-Routine%20inspection%20for%201803_243%20Franklin%20St%2C%20Melbo-92.pdf">Routine inspection for 1803/243 Franklin St, Melbo</a></td>
+<tr><td><a href="20250430-Routine%20inspection%20for%201803_243%20Franklin%20St%2C%20Melbo-92.pdf">Routine inspection for 1803/243 Franklin St, Melbo</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/30/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">33.18 KB</td></tr>
-<tr><td><a href="messages/20250428-Update%20on%20Leak%20Issue%20at%201803_%20243%20Franklin-93.pdf">Update on Leak Issue at 1803/ 243 Franklin</a></td>
+<tr><td><a href="20250428-Update%20on%20Leak%20Issue%20at%201803_%20243%20Franklin-93.pdf">Update on Leak Issue at 1803/ 243 Franklin</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/28/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">50.24 KB</td></tr>
-<tr><td><a href="messages/20250428-Update%20on%20Leak%20Inspection-1803_243%20Franklin-94.pdf">Update on Leak Inspection-1803/243 Franklin</a></td>
+<tr><td><a href="20250428-Update%20on%20Leak%20Inspection-1803_243%20Franklin-94.pdf">Update on Leak Inspection-1803/243 Franklin</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/28/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">585.53 KB</td></tr>
-<tr><td><a href="messages/20250424-Re_FW_%20Second%20Follow-up_%20Urgent%20Water%20Damage%20Escal-95.pdf">Re: FW: Second Follow-up: Urgent Water Damage Escalati</a></td>
+<tr><td><a href="20250424-Re_FW_%20Second%20Follow-up_%20Urgent%20Water%20Damage%20Escal-95.pdf">Re: FW: Second Follow-up: Urgent Water Damage Escalati</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>ck.chawakorn@gmail.com</td>
 <td nowrap>4/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">69.77 KB</td></tr>
-<tr><td><a href="messages/20250424-Routine%20inspection%20scheduled%20for%201803_243%20Franklin-96.pdf">Routine inspection scheduled for 1803/243 Franklin</a></td>
+<tr><td><a href="20250424-Routine%20inspection%20scheduled%20for%201803_243%20Franklin-96.pdf">Routine inspection scheduled for 1803/243 Franklin</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/24/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">33.17 KB</td></tr>
-<tr><td><a href="messages/20250423-Second%20Follow-up_%20Urgent%20Water%20Damage%20Escalation%20%E2%80%93-97.pdf">Second Follow-up: Urgent Water Damage Escalation –</a></td>
+<tr><td><a href="20250423-Second%20Follow-up_%20Urgent%20Water%20Damage%20Escalation%20%E2%80%93-97.pdf">Second Follow-up: Urgent Water Damage Escalation –</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>sylvia.hao@areal.com.au</td>
 <td nowrap>4/23/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">5.4 MB</td></tr>
-<tr><td><a href="messages/20250423-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-98.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
+<tr><td><a href="20250423-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-98.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
 <td>Sylvia Hao - Areal Property Hawthorn (MPM)" &lt;MPM@</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/23/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">140.42 KB</td></tr>
-<tr><td><a href="messages/20250420-Automatic%20reply_%20Urgent_%20Water%20Damage%20on%20Bedroom%20W-99.pdf">Automatic reply: Urgent: Water Damage on Bedroom W</a></td>
+<tr><td><a href="20250420-Automatic%20reply_%20Urgent_%20Water%20Damage%20on%20Bedroom%20W-99.pdf">Automatic reply: Urgent: Water Damage on Bedroom W</a></td>
 <td>Hilary Ho &lt;hilary.ho@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/20/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">14.22 KB</td></tr>
-<tr><td><a href="messages/20250420-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-103.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
+<tr><td><a href="20250420-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-103.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Hilary Ho &lt;hilary.ho@areal.com.au&gt;</td>
 <td nowrap>4/20/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">5.15 MB</td></tr>
-<tr><td><a href="messages/20250416-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-102.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
+<tr><td><a href="20250416-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-102.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>Hilary Ho &lt;hilary.ho@areal.com.au&gt;</td>
 <td nowrap>4/16/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">241.33 KB</td></tr>
-<tr><td><a href="messages/20250416-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-101.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
+<tr><td><a href="20250416-Re_Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803-101.pdf">Re: Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
 <td>Hilary Ho &lt;hilary.ho@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/16/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">257.53 KB</td></tr>
-<tr><td><a href="messages/20250416-Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803)-100.pdf">Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
+<tr><td><a href="20250416-Urgent_%20Water%20Damage%20on%20Bedroom%20Wall%20(Unit%201803)-100.pdf">Urgent: Water Damage on Bedroom Wall (Unit 1803)</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>hilary.ho@areal.com.au</td>
 <td nowrap>4/16/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">8.76 MB</td></tr>
-<tr><td><a href="messages/20250409-Re_Non-Urgent%20Maintenance%20Request%20(1803_243%20Frankl-106.pdf">Re: Non-Urgent Maintenance Request (1803/243 Franklin </a></td>
+<tr><td><a href="20250409-Re_Non-Urgent%20Maintenance%20Request%20(1803_243%20Frankl-106.pdf">Re: Non-Urgent Maintenance Request (1803/243 Franklin </a></td>
 <td>Hilary Ho &lt;hilary.ho@areal.com.au&gt;</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/09/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">265.77 KB</td></tr>
-<tr><td><a href="messages/20250408-Fwd_%20Non-Urgent%20Maintenance%20Request%20(1803_243%20Fran-105.pdf">Fwd: Non-Urgent Maintenance Request (1803/243 Fran</a></td>
+<tr><td><a href="20250408-Fwd_%20Non-Urgent%20Maintenance%20Request%20(1803_243%20Fran-105.pdf">Fwd: Non-Urgent Maintenance Request (1803/243 Fran</a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>hilary.ho@areal.com.au</td>
 <td nowrap>4/08/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">17.19 MB</td></tr>
-<tr><td><a href="messages/20250402-Non-Urgent%20Maintenance%20Request%20(1803_243%20Franklin%20-104.pdf">Non-Urgent Maintenance Request (1803/243 Franklin </a></td>
+<tr><td><a href="20250402-Non-Urgent%20Maintenance%20Request%20(1803_243%20Franklin%20-104.pdf">Non-Urgent Maintenance Request (1803/243 Franklin </a></td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td>mpm@email.propertyme.com</td>
 <td nowrap>4/02/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">17.18 MB</td></tr>
-<tr><td><a href="messages/20250401-Areal%20monthly%20after-hours%20trades%20list%20update-107.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250401-Areal%20monthly%20after-hours%20trades%20list%20update-107.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Hilary Ho - Areal Property Hawthorn (MPM)" &lt;MPM@e</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>4/01/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.41 KB</td></tr>
-<tr><td><a href="messages/20250325-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-108.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
+<tr><td><a href="20250325-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-108.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
 <td>Hilary Ho - Areal Property Hawthorn (MPM)" &lt;MPM@e</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>3/25/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">140.61 KB</td></tr>
-<tr><td><a href="messages/20250325-Areal%20monthly%20after-hours%20trades%20list%20update-109.pdf">Areal monthly after-hours trades list update</a></td>
+<tr><td><a href="20250325-Areal%20monthly%20after-hours%20trades%20list%20update-109.pdf">Areal monthly after-hours trades list update</a></td>
 <td>Hilary Ho - Areal Property Hawthorn (MPM)" &lt;MPM@e</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>3/25/2025</td>
 <td align="center">&nbsp;</td>
 <td nowrap align="left">45.8 KB</td></tr>
-<tr><td><a href="messages/20250225-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-110.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
+<tr><td><a href="20250225-Receipt%20of%20payment%20for%201803_243%20Franklin%20St%2C%20Melbo-110.pdf">Receipt of payment for 1803/243 Franklin St, Melbo</a></td>
 <td>Jessica Xie - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>2/25/2025</td>
 <td align="center">* </td>
 <td nowrap align="left">135.76 KB</td></tr>
-<tr><td><a href="messages/20250207-Welcome%20to%20Areal%20Property%20%E2%80%93%20Your%20New%20Property%20Mana-111.pdf">Welcome to Areal Property – Your New Property Mana</a></td>
+<tr><td><a href="20250207-Welcome%20to%20Areal%20Property%20%E2%80%93%20Your%20New%20Property%20Mana-111.pdf">Welcome to Areal Property – Your New Property Mana</a></td>
 <td>Jessica Xie - Areal Property Hawthorn (MPM)" &lt;MPM</td>
 <td>Chawakorn Kamnuansil &lt;ck.chawakorn@gmail.com&gt;</td>
 <td nowrap>2/07/2025</td>


### PR DESCRIPTION
## Summary
- point PDF links in `index.html` directly to repository root by removing stale `messages/` prefix

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for pdfminer.six==20241021)*
- `python scripts/build_index.py` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_68b423aa30a0832c9e590a8d95aa161a