### PR TITLE
Add text search CLI and usage guide

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,35 @@
+# Repository usage
+
+This repository stores evidence PDFs alongside plain‑text extracts.
+The text files live in the [`_text/`](./_text) directory and enable
+search for both humans and downstream AI tools.
+
+## Quick search from the command line
+
+```bash
+python search.py "water damage"
+```
+
+The script prints one matching line per file and is case‑insensitive.
+Use `-n` to limit the number of results:
+
+```bash
+python search.py "rent" -n 5
+```
+
+## Browser search interface
+
+Open [`docs/index.html`](./docs/index.html) in a web browser to perform
+client‑side searches with a graphical interface.
+
+## Updating the index
+
+When new PDFs are added:
+
+1. Run [`make_pdfs_searchable.sh`](./make_pdfs_searchable.sh) to OCR any
+   files lacking a text layer.
+2. Run [`setup_search_pages.sh`](./setup_search_pages.sh) to rebuild the
+   text extracts and search index.
+
+These steps keep the repository fully accessible for humans and AI
+systems.

--- a/search.py
+++ b/search.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Lightweight text search for this repository.
+
+The script scans the `_text` directory for `.txt` files (generated from
+PDFs) and prints the first matching line for a given query. Results are
+limited to one hit per file, making the output easy to parse by humans or
+downstream AI tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+TEXT_DIR = Path("_text")
+
+
+def search_files(query: str):
+    """Yield dictionaries with filename, line number and snippet."""
+    query_lower = query.lower()
+    for txt_path in sorted(TEXT_DIR.glob("*.txt")):
+        try:
+            text = txt_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        lines = text.splitlines()
+        for idx, line in enumerate(lines, start=1):
+            if query_lower in line.lower():
+                yield {
+                    "file": txt_path.name,
+                    "line": idx,
+                    "snippet": line.strip(),
+                }
+                break
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Search `_text` for a query")
+    parser.add_argument("query", help="text to look for")
+    parser.add_argument("-n", "--limit", type=int, default=10, help="maximum results")
+    args = parser.parse_args(argv)
+
+    if not TEXT_DIR.is_dir():
+        print(f"Missing directory: {TEXT_DIR}", file=sys.stderr)
+        return 1
+
+    results = []
+    for match in search_files(args.query):
+        results.append(match)
+        if len(results) >= args.limit:
+            break
+
+    if not results:
+        print("No matches found.")
+        return 0
+
+    for match in results:
+        snippet = match["snippet"]
+        if len(snippet) > 200:
+            snippet = snippet[:197] + "..."
+        print(f"{match['file']}:{match['line']} {snippet}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `search.py` for quick keyword lookup across `_text` documents
- document how to search and rebuild the index in `USAGE.md`

## Testing
- `python -m py_compile search.py`
- `python search.py "rent" -n 3`


------
https://chatgpt.com/codex/tasks/task_e_68b42a2a7630832ca094f88a6c5c6e46