### PR TITLE
Add CI workflow with lint and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt flake8 pytest
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -36,16 +36,19 @@ def main() -> None:
         for pdf in sorted(glob.glob("*.pdf")):
             try:
                 n = pages(pdf)
+                pdf_name = os.path.basename(pdf)
                 for i in range(1, n + 1):
                     txt = extract_text(pdf, page_numbers=[i - 1]) or ""
                     if txt.strip():
                         out.write(
                             json.dumps(
                                 {
-                                    "file": os.path.basename(pdf),
+                                    "file": pdf_name,
                                     "page": i,
                                     "text": cut(txt, args.snippet_length),
-                                    "url": f"{args.base_url}/{os.path.basename(pdf)}#page={i}",
+                                    "url": (
+                                        f"{args.base_url}/{pdf_name}#page={i}"
+                                    ),
                                 },
                                 ensure_ascii=False,
                             )

--- a/tests/test_build_index.py
+++ b/tests/test_build_index.py
@@ -1,0 +1,15 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "build_index",
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "build_index.py",
+)
+build_index = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_index)
+
+
+def test_cut_truncates_with_ellipsis():
+    assert build_index.cut("abcdefghij", 5) == "abcde…"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to lint and test
- add unit test for `build_index.cut`
- refactor `build_index` to satisfy flake8

## Testing
- `pip install -r requirements.txt flake8 pytest` *(fails: No matching distribution found for pdfminer.six==20241021)*
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42ad0b04c832cbf4df295578dfe8a