### PR TITLE
test: convert escape script to node test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 > Auto-generated. Click to view each PDF in-browser (main branch).
 
+## Tests
+
+Run the test suite with:
+
+```bash
+node --test
+```
+
 - [`2025-02-22_Rent_Receipt.pdf`](https://github.com/ck999kk/PDF.git/blob/main/2025-02-22_Rent_Receipt.pdf)
 - [`2025-03-21_Rent_Receipt.pdf`](https://github.com/ck999kk/PDF.git/blob/main/2025-03-21_Rent_Receipt.pdf)
 - [`2025-04-21_Rent_Receipt.pdf`](https://github.com/ck999kk/PDF.git/blob/main/2025-04-21_Rent_Receipt.pdf)

--- a/scripts/test_escape.js
+++ b/scripts/test_escape.js
@@ -1,7 +1,0 @@
-const assert = require('assert');
-
-const esc = s => s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
-
-assert.strictEqual(esc('<script>'), '&lt;script&gt;');
-
-console.log('escape ok');

--- a/tests/escape.test.js
+++ b/tests/escape.test.js
@@ -1,0 +1,8 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const esc = s => s.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+
+test('escapes HTML special characters', () => {
+  assert.strictEqual(esc('<script>'), '&lt;script&gt;');
+});


### PR DESCRIPTION
## Summary
- migrate `test_escape.js` to Node's built-in test runner
- relocate script to `tests/escape.test.js`
- document `node --test` usage in README

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b42e8ccacc832c87c128d8f5e0dbd7